### PR TITLE
feat: adding fee receiver contract + tests + deploy

### DIFF
--- a/script/deploy_FeeReceiver.s.sol
+++ b/script/deploy_FeeReceiver.s.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "forge-std/Script.sol";
+
+import {FeeReceiver} from "src/strategy/FeeReceiver.sol";
+
+/*
+
+function run() public {
+        vm.startBroadcast(deployer);
+
+        ImmutableCreate2Factory factory = ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
+
+        address expectedAddress = 0x0000000895cB182E6f983eb4D8b4E0Aa0B31Ae4c;
+        bytes32 salt = bytes32(0x00000000000000000000000000000000000000009507c6bc18ba0210002d039b);
+        /// CURVE
+        /// Address: 0x00000006a9C3E87Bd203ecde071665a6eAabe5EA
+        /// Salt: 0x0000000000000000000000000000000000000000696e3563d59d23800099f57b
+        _deployPlatform(factory, CURVE_CONTROLLER, salt, expectedAddress);
+
+        vm.stopBroadcast();
+    }
+
+    function _deployPlatform(ImmutableCreate2Factory factory, address controller, bytes32 salt, address expectedAddress)
+        internal
+    {
+        factory.safeCreate2(
+            salt, abi.encodePacked(type(Platform).creationCode, abi.encode(controller, owner, deployer))
+        );
+
+        Platform platform = Platform(address(expectedAddress));
+
+*/
+
+interface ImmutableCreate2Factory {
+    function safeCreate2(bytes32, bytes memory) external;
+}
+
+contract PlatformScript is Script, Test {
+    /// Executor
+    address deployer = 0x90569D8A1cF801709577B24dA526118f0C83Fc75;
+    
+    /// Multisig
+    address governance = address(0xF930EBBd05eF8b25B1797b9b2109DDC9B0d43063);
+
+    function run() public {
+        vm.startBroadcast(deployer);
+
+        ImmutableCreate2Factory factory = ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
+
+        address expectedAddress = 0x0000002127E998fdd4149718664D5853b82E3557;
+
+        bytes32 salt = bytes32(0x0000000000000000000000000000000000000000b46a76edbedbb50199e99276);
+        
+        factory.safeCreate2(
+            salt, abi.encodePacked(type(FeeReceiver).creationCode, abi.encode(deployer, governance, governance))
+        );
+
+        FeeReceiver feeReceiver = FeeReceiver(address(expectedAddress));
+
+        assertEq(feeReceiver.governance(), deployer);
+        assertEq(feeReceiver.dao(), governance);
+        assertEq(feeReceiver.veSdtFeeProxy(), governance);
+        assertEq(feeReceiver.futureGovernance(), address(0));
+
+        vm.stopBroadcast();
+    }
+
+}

--- a/src/strategy/FeeReceiver.sol
+++ b/src/strategy/FeeReceiver.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.19;
+
+import {ERC20} from "solady/tokens/ERC20.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+
+/// @title A contract that receive reward tokens from Strategies on harvest, and split them according to the fee structure specified (per Accumulator)
+/// @author StakeDAO
+contract FeeReceiver {
+    struct Repartition {
+        uint256 dao;
+        uint256 accumulator;
+        uint256 veSdtFeeProxy;
+    }
+
+    /// @notice governance
+    address public governance;
+
+    /// @notice future governance
+    address public futureGovernance;
+
+    /// @notice dao address
+    address public dao;
+
+    /// @notice veSdtFeeProxy address
+    address public veSdtFeeProxy;
+
+    /// @notice Base fee (10_000 = 100%)
+    uint256 private constant BASE_FEE = 10_000;
+
+    /// @notice Accumulator => Reward token
+    /// @dev Allows multiple strategies to use that contract
+    mapping(address accumulator => address rewardToken) public accumulatorRewardToken;
+
+    /// @notice Accumulator => Repartition structure
+    /// @dev Each accumulator/rewardToken can have a specific fee structure
+    mapping(address accumulator => Repartition) public accumulatorRepartition;
+
+    ////////////////////////////////////////////////////////////
+    /// --- EVENTS & ERRORS ---
+    ////////////////////////////////////////////////////////////
+
+    /// @notice Event emitted when the reward token is split between the different parties
+    /// @param accumulator accumulator address
+    /// @param rewardToken reward token address
+    /// @param daoPart dao part
+    /// @param accumulatorPart accumulator part
+    /// @param veSdtFeeProxyPart veSdtFeeProxy part
+    event Split(
+        address indexed accumulator,
+        address indexed rewardToken,
+        uint256 daoPart,
+        uint256 accumulatorPart,
+        uint256 veSdtFeeProxyPart
+    );
+
+    /// @notice Event emitted when a new future governance has set
+    event TransferGovernance(address futureGovernance);
+
+    /// @notice Event emitted when the future governance accepts to be the governance
+    event GovernanceChanged(address governance);
+
+    /// @notice Error emitted when an onlyGovernance function has called by a different address
+    error GOVERNANCE();
+
+    /// @notice Error emitted when an onlyFutureGovernance function has called by a different address
+    error FUTURE_GOVERNANCE();
+
+    /// @notice Error emitted when a zero address is pass
+    error ZERO_ADDRESS();
+
+    /// @notice Error emitted when the accumulator is not setted
+    error UNKNOWN_ACCUMULATOR();
+
+    /// @notice Error emitted when the repartition is not setted for the accumulator
+    error REPARTITION_NOT_SET();
+
+    /// @notice Error emitted when the total setted fee is invalid (not equal to 100%)
+    error INVALID_FEE();
+
+    //////////////////////////////////////////////////////
+    /// --- MODIFIERS
+    //////////////////////////////////////////////////////
+
+    /// @notice Modifier to check if the caller is the governance
+    modifier onlyGovernance() {
+        if (msg.sender != governance) revert GOVERNANCE();
+        _;
+    }
+
+    /// @notice Modifier to check if the caller is the future governance
+    modifier onlyFutureGovernance() {
+        if (msg.sender != futureGovernance) revert FUTURE_GOVERNANCE();
+        _;
+    }
+
+    constructor(address _governance, address _veSdtFeeProxy, address _dao) {
+        if (_veSdtFeeProxy == address(0) || _dao == address(0)) revert ZERO_ADDRESS();
+        governance = _governance; 
+        dao = _dao;
+        veSdtFeeProxy = _veSdtFeeProxy;
+    }
+
+    /// @notice Split the token between the different parties
+    /// @dev Only an accumulator can call this function
+    /// @dev Reward token address is taken from the mapping, if not found, revert
+    function split() external {
+        address rewardToken = accumulatorRewardToken[msg.sender];
+
+        // If the reward token is not set, for the msg.sender revert
+        if (rewardToken == address(0)) {
+            revert UNKNOWN_ACCUMULATOR();
+        }
+
+        Repartition memory repartition = accumulatorRepartition[msg.sender];
+
+        // If the repartition is not set, for the msg.sender revert
+        if (repartition.dao == 0 && repartition.accumulator == 0 && repartition.veSdtFeeProxy == 0) {
+            revert REPARTITION_NOT_SET();
+        }
+
+        // Can be some leftovers (rounding issues from prev split)
+        uint256 totalBalance = ERC20(rewardToken).balanceOf(address(this));
+
+        if (totalBalance == 0) {
+            return;
+        }
+
+        uint256 daoPart;
+        uint256 accumulatorPart;
+        uint256 veSdtFeeProxyPart;
+
+        // DAO part
+        if (repartition.dao > 0) {
+            daoPart = totalBalance * repartition.dao / BASE_FEE;
+            SafeTransferLib.safeTransfer(rewardToken, dao, daoPart);
+        }
+
+        // veSdtFeeProxy part
+        if (repartition.veSdtFeeProxy > 0) {
+            veSdtFeeProxyPart = totalBalance * repartition.veSdtFeeProxy / BASE_FEE;
+            SafeTransferLib.safeTransfer(rewardToken, veSdtFeeProxy, veSdtFeeProxyPart);
+        }
+
+        // Accumulator part
+        if (repartition.accumulator > 0) {
+            accumulatorPart = totalBalance * repartition.accumulator / BASE_FEE;
+            SafeTransferLib.safeTransfer(rewardToken, msg.sender, accumulatorPart);
+        }
+
+        emit Split(msg.sender, rewardToken, daoPart, accumulatorPart, veSdtFeeProxyPart);
+    }
+
+    //////////////////////////////////////////////////////
+    /// --- GOVERNANCE FUNCTIONS
+    //////////////////////////////////////////////////////
+
+    /// @notice Set a new future governance that can accept it
+    /// @dev Can be called only by the governance
+    /// @param _futureGovernance future governance address
+    function transferGovernance(address _futureGovernance) external onlyGovernance {
+        if (_futureGovernance == address(0)) revert ZERO_ADDRESS();
+        futureGovernance = _futureGovernance;
+        emit TransferGovernance(_futureGovernance);
+    }
+
+    /// @notice Accept the governance
+    /// @dev Can be called only by future governance
+    function acceptGovernance() external onlyFutureGovernance {
+        governance = futureGovernance;
+        futureGovernance = address(0);
+        emit GovernanceChanged(governance);
+    }
+
+    /// @notice Set both the reward token and the repartition for the accumulator
+    /// @dev Can be called only by the governance
+    /// @dev Will override the previous reward token and repartition if already set
+    /// @param accumulator accumulator address
+    /// @param rewardToken reward token address
+    /// @param daoPart dao part
+    /// @param accumulatorPart accumulator part
+    /// @param veSdtFeeProxyPart veSdtFeeProxy part
+    function setRewardTokenAndRepartition(
+        address accumulator,
+        address rewardToken,
+        uint256 daoPart,
+        uint256 accumulatorPart,
+        uint256 veSdtFeeProxyPart
+    ) external onlyGovernance {
+        if (accumulator == address(0) || rewardToken == address(0)) revert ZERO_ADDRESS();
+        if (daoPart + accumulatorPart + veSdtFeeProxyPart != BASE_FEE) revert INVALID_FEE();
+
+        accumulatorRewardToken[accumulator] = rewardToken;
+        accumulatorRepartition[accumulator] = Repartition(daoPart, accumulatorPart, veSdtFeeProxyPart);
+    }
+
+    /// @notice Set the repartition for the accumulator
+    /// @dev Can be called only by the governance
+    /// @param accumulator accumulator address
+    /// @param daoPart dao part
+    /// @param accumulatorPart accumulator part
+    /// @param veSdtFeeProxyPart veSdtFeeProxy part
+    /// @dev Accumulator must be already set
+    function setRepartition(address accumulator, uint256 daoPart, uint256 accumulatorPart, uint256 veSdtFeeProxyPart)
+        external
+        onlyGovernance
+    {
+        if (accumulatorRewardToken[accumulator] == address(0)) revert UNKNOWN_ACCUMULATOR();
+        if (daoPart + accumulatorPart + veSdtFeeProxyPart != BASE_FEE) revert INVALID_FEE();
+
+        accumulatorRepartition[accumulator] = Repartition(daoPart, accumulatorPart, veSdtFeeProxyPart);
+    }
+
+    /// @notice Set dao address
+    /// @dev Can be called only by the governance
+    /// @param _dao dao address
+    function setDao(address _dao) external onlyGovernance {
+        if (_dao == address(0)) revert ZERO_ADDRESS();
+        dao = _dao;
+    }
+
+    /// @notice Set veSdtFeeProxy address
+    /// @dev Can be called only by the governance
+    /// @param _veSdtFeeProxy veSdtFeeProxy address
+    function setVeSdtFeeProxy(address _veSdtFeeProxy) external onlyGovernance {
+        if (_veSdtFeeProxy == address(0)) revert ZERO_ADDRESS();
+        veSdtFeeProxy = _veSdtFeeProxy;
+    }
+}

--- a/test/strategy/FeeReceiverTest.t.sol
+++ b/test/strategy/FeeReceiverTest.t.sol
@@ -113,6 +113,23 @@ contract FeeReceiverTest is Test {
         assertEq(tokenA.balanceOf(veSdtFeeProxy), amount * 25 / 100);
     }
 
+
+    function test_splitFeeWithOneZero(uint256 amount) public {
+        vm.assume(amount < type(uint256).max / 10_000);
+        tokenA.mint(address(feeReceiver), amount);
+
+        vm.startPrank(governance);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(tokenA), 0, 5_000, 5_000);
+        vm.stopPrank();
+
+        vm.prank(accumulator);
+        feeReceiver.split();
+
+        assertEq(tokenA.balanceOf(dao), 0);
+        assertEq(tokenA.balanceOf(accumulator), amount * 50 / 100);
+        assertEq(tokenA.balanceOf(veSdtFeeProxy), amount * 50 / 100);
+    }
+
     function test_splitFeeMultipleRewardTokens(uint256 amountA, uint256 amountB, uint256 amountC) public {
         vm.assume(amountA < type(uint256).max / 10_000);
         vm.assume(amountB < type(uint256).max / 10_000);

--- a/test/strategy/FeeReceiverTest.t.sol
+++ b/test/strategy/FeeReceiverTest.t.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.19;
+
+import "forge-std/Vm.sol";
+import "forge-std/Test.sol";
+
+import {FeeReceiver} from "src/strategy/FeeReceiver.sol";
+import {MockERC20} from "lib/solady/test/utils/mocks/MockERC20.sol";
+
+contract FeeReceiverTest is Test {
+    //MockERC20 public rewardToken;
+    FeeReceiver public feeReceiver;
+
+    address public veSdtFeeProxy = address(0xBadC0de);
+    address public dao = address(0xBA5EBA11);
+    address public accumulator = address(0xBEA7ED);
+
+    address public governance = address(0xB055);
+
+    MockERC20 public tokenA = new MockERC20("Token A", "TKA", 18);
+    MockERC20 public tokenB = new MockERC20("Token B", "TKB", 16);
+    MockERC20 public tokenC = new MockERC20("Token C", "TKC", 8);
+
+    function setUp() public {
+        feeReceiver = new FeeReceiver(governance, veSdtFeeProxy, dao);
+        }
+
+    function test_getBytecode() public {
+        address owner = address(0xF930EBBd05eF8b25B1797b9b2109DDC9B0d43063);
+        bytes memory bytecode = abi.encodePacked(type(FeeReceiver).creationCode, abi.encode(0x90569D8A1cF801709577B24dA526118f0C83Fc75, owner, owner));
+        console.logBytes32(keccak256(bytecode));
+    }
+
+    function test_initialSetup() public {
+
+        assertEq(feeReceiver.veSdtFeeProxy(), veSdtFeeProxy);
+        assertEq(feeReceiver.dao(), dao);
+        assertEq(feeReceiver.governance(), governance);
+        assertEq(feeReceiver.futureGovernance(), address(0));
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// --- GOVERNANCE ---
+    ////////////////////////////////////////////////////////////
+
+    function test_transferGovernance() public {
+        vm.prank(governance);
+        feeReceiver.transferGovernance(address(0x4));
+        assertEq(feeReceiver.futureGovernance(), address(0x4));
+    }
+
+    function test_acceptGovernance() public {
+        vm.prank(governance);
+        feeReceiver.transferGovernance(address(0x4));
+
+        vm.prank(address(0x4));
+        feeReceiver.acceptGovernance();
+        assertEq(feeReceiver.governance(), address(0x4));
+        assertEq(feeReceiver.futureGovernance(), address(0));
+    }
+
+    function test_setDao() public {
+        vm.prank(governance);
+        feeReceiver.setDao(address(0x5));
+        assertEq(feeReceiver.dao(), address(0x5));
+    }
+
+    function test_setVeSdtFeeProxy() public {
+        vm.prank(governance);
+        feeReceiver.setVeSdtFeeProxy(address(0x6));
+        assertEq(feeReceiver.veSdtFeeProxy(), address(0x6));
+    }
+
+    function test_setRewardTokenAndRepartition() public {
+        vm.prank(governance);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(tokenA), 2_500, 5_000, 2_500);
+        assertEq(feeReceiver.accumulatorRewardToken(accumulator), address(tokenA));
+
+        (uint256 daoPart, uint256 accumulatorPart, uint256 veSdtFeeProxyPart) =
+            feeReceiver.accumulatorRepartition(accumulator);
+        assertEq(daoPart, 2_500);
+        assertEq(accumulatorPart, 5_000);
+        assertEq(veSdtFeeProxyPart, 2_500);
+
+        // Changing using setRepartition
+        vm.prank(governance);
+        feeReceiver.setRepartition(accumulator, 1_000, 8_000, 1_000);
+
+        (daoPart, accumulatorPart, veSdtFeeProxyPart) = feeReceiver.accumulatorRepartition(accumulator);
+
+        assertEq(daoPart, 1_000);
+        assertEq(accumulatorPart, 8_000);
+        assertEq(veSdtFeeProxyPart, 1_000);
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// --- SPLIT FEE ---
+    ////////////////////////////////////////////////////////////
+
+    function test_splitFee(uint256 amount) public {
+        vm.assume(amount < type(uint256).max / 10_000);
+        tokenA.mint(address(feeReceiver), amount);
+
+        vm.startPrank(governance);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(tokenA), 2_500, 5_000, 2_500);
+        vm.stopPrank();
+
+        vm.prank(accumulator);
+        feeReceiver.split();
+
+        assertEq(tokenA.balanceOf(dao), amount * 25 / 100);
+        assertEq(tokenA.balanceOf(accumulator), amount * 50 / 100);
+        assertEq(tokenA.balanceOf(veSdtFeeProxy), amount * 25 / 100);
+    }
+
+    function test_splitFeeMultipleRewardTokens(uint256 amountA, uint256 amountB, uint256 amountC) public {
+        vm.assume(amountA < type(uint256).max / 10_000);
+        vm.assume(amountB < type(uint256).max / 10_000);
+        vm.assume(amountC < type(uint256).max / 10_000);
+
+        vm.assume(amountA > 0);
+        vm.assume(amountB > 0);
+        vm.assume(amountC > 0);
+
+        tokenA.mint(address(feeReceiver), amountA);
+        tokenB.mint(address(feeReceiver), amountB);
+        tokenC.mint(address(feeReceiver), amountC);
+
+        uint256 repartitionDaoA = 7273; // 72.73%
+        uint256 repartitionAccumulatorA = 2087; // 20.87%
+        uint256 repartitionVeSdtFeeProxyA = 640; // 6.4%
+
+        uint256 repartitionDaoB = 6000; // 60%
+        uint256 repartitionAccumulatorB = 3000; // 30%
+        uint256 repartitionVeSdtFeeProxyB = 1000; // 10%
+
+        uint256 repartitionDaoC = 100; // 1%
+        uint256 repartitionAccumulatorC = 500; // 5%
+        uint256 repartitionVeSdtFeeProxyC = 9400; // 94%
+
+        // One accumulator for each token
+        vm.startPrank(governance);
+        feeReceiver.setRewardTokenAndRepartition(
+            accumulator, address(tokenA), repartitionDaoA, repartitionAccumulatorA, repartitionVeSdtFeeProxyA
+        );
+        feeReceiver.setRewardTokenAndRepartition(
+            address(0x1), address(tokenB), repartitionDaoB, repartitionAccumulatorB, repartitionVeSdtFeeProxyB
+        );
+        feeReceiver.setRewardTokenAndRepartition(
+            address(0x2), address(tokenC), repartitionDaoC, repartitionAccumulatorC, repartitionVeSdtFeeProxyC
+        );
+        vm.stopPrank();
+
+        // Token A
+        vm.prank(accumulator);
+        feeReceiver.split();
+
+        assertEq(tokenA.balanceOf(dao), amountA * repartitionDaoA / 10_000);
+        assertEq(tokenA.balanceOf(accumulator), amountA * repartitionAccumulatorA / 10_000);
+        assertEq(tokenA.balanceOf(veSdtFeeProxy), amountA * repartitionVeSdtFeeProxyA / 10_000);
+
+        // Assert does not touched other tokens
+        assertEq(tokenB.balanceOf(address(feeReceiver)), amountB);
+        assertEq(tokenC.balanceOf(address(feeReceiver)), amountC);
+
+        // Token B
+        vm.prank(address(0x1));
+        feeReceiver.split();
+
+        assertEq(tokenA.balanceOf(dao), amountA * repartitionDaoA / 10_000);
+        assertEq(tokenA.balanceOf(accumulator), amountA * repartitionAccumulatorA / 10_000);
+        assertEq(tokenA.balanceOf(veSdtFeeProxy), amountA * repartitionVeSdtFeeProxyA / 10_000);
+
+        assertEq(tokenB.balanceOf(dao), amountB * repartitionDaoB / 10_000);
+        assertEq(tokenB.balanceOf(address(0x1)), amountB * repartitionAccumulatorB / 10_000);
+        assertEq(tokenB.balanceOf(veSdtFeeProxy), amountB * repartitionVeSdtFeeProxyB / 10_000);
+
+        // Assert does not touched other tokens
+        assertEq(tokenC.balanceOf(address(feeReceiver)), amountC);
+
+        // Token C
+        vm.prank(address(0x2));
+        feeReceiver.split();
+
+        assertEq(tokenA.balanceOf(dao), amountA * repartitionDaoA / 10_000);
+        assertEq(tokenA.balanceOf(accumulator), amountA * repartitionAccumulatorA / 10_000);
+        assertEq(tokenA.balanceOf(veSdtFeeProxy), amountA * repartitionVeSdtFeeProxyA / 10_000);
+
+        assertEq(tokenB.balanceOf(dao), amountB * repartitionDaoB / 10_000);
+        assertEq(tokenB.balanceOf(address(0x1)), amountB * repartitionAccumulatorB / 10_000);
+        assertEq(tokenB.balanceOf(veSdtFeeProxy), amountB * repartitionVeSdtFeeProxyB / 10_000);
+
+        assertEq(tokenC.balanceOf(dao), amountC * repartitionDaoC / 10_000);
+        assertEq(tokenC.balanceOf(address(0x2)), amountC * repartitionAccumulatorC / 10_000);
+        assertEq(tokenC.balanceOf(veSdtFeeProxy), amountC * repartitionVeSdtFeeProxyC / 10_000);
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// --- REVERTS ---
+    ////////////////////////////////////////////////////////////
+
+    function test_unauthorizedTransferGovernance() public {
+        vm.expectRevert(FeeReceiver.GOVERNANCE.selector);
+        feeReceiver.transferGovernance(address(0x4));
+
+        vm.prank(address(0x4));
+        vm.expectRevert(FeeReceiver.FUTURE_GOVERNANCE.selector);
+        feeReceiver.acceptGovernance();
+    }
+
+    function test_governanceAddressZero() public {
+        vm.expectRevert(FeeReceiver.ZERO_ADDRESS.selector);
+        vm.prank(governance);
+        feeReceiver.transferGovernance(address(0));
+    }
+
+    function test_unauthorizedSetRewardTokenAndRepartition() public {
+        vm.expectRevert(FeeReceiver.GOVERNANCE.selector);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(tokenA), 2_500, 5_000, 2_500);
+
+        vm.expectRevert(FeeReceiver.GOVERNANCE.selector);
+        feeReceiver.setRepartition(accumulator, 1_000, 8_000, 1_000);
+    }
+
+    function test_unknownAccumulatorForSplit() public {
+        vm.expectRevert(FeeReceiver.UNKNOWN_ACCUMULATOR.selector);
+        feeReceiver.split();
+    }
+
+    function test_invalidFeeOnSetRewardTokenAndRepartition() public {
+        vm.expectRevert(FeeReceiver.INVALID_FEE.selector);
+        vm.prank(governance);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(tokenA), 2_500, 5_000, 2_501);
+    }
+
+    function test_invalidFeeOnSetRepartition() public {
+        vm.prank(governance);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(tokenA), 2_500, 5_000, 2_500);
+
+        vm.expectRevert(FeeReceiver.INVALID_FEE.selector);
+        vm.prank(governance);
+        feeReceiver.setRepartition(accumulator, 0, 40, 100);
+    }
+
+    function test_zeroAddresses() public {
+        vm.expectRevert(FeeReceiver.ZERO_ADDRESS.selector);
+        vm.prank(governance);
+        feeReceiver.setRewardTokenAndRepartition(address(0), address(tokenA), 2_500, 5_000, 2_500);
+
+        vm.expectRevert(FeeReceiver.ZERO_ADDRESS.selector);
+        vm.prank(governance);
+        feeReceiver.setRewardTokenAndRepartition(accumulator, address(0), 2_500, 5_000, 2_500);
+
+        vm.expectRevert(FeeReceiver.ZERO_ADDRESS.selector);
+        vm.prank(governance);
+        feeReceiver.setDao(address(0));
+
+        vm.expectRevert(FeeReceiver.ZERO_ADDRESS.selector);
+        vm.prank(governance);
+        feeReceiver.setVeSdtFeeProxy(address(0));
+    }
+}


### PR DESCRIPTION
- Receiver for strategies, splitting received fees between DAO ; veSDT, and accumulator. 
- Allowing multiple reward tokens (multiple strategies); linked to corresponding accumulators.
- Split is callable only by Accumulators, and will do the split according to the fee structure defined for the corresponding reward token 
- If reward token not specified (accumulator not putted in the contract via `setRewardTokenAndRepartition`; revert).
- Maybe allowing a public `split(address rewardToken)` ; allowing anyone besides the accumulator to call it ? (but no interest since no incentives.)